### PR TITLE
Fixes intall step in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Install [Node.js](http://nodejs.org/)
 
 Install david:
 
-	npm install david
+	npm install
 
 Use:
 


### PR DESCRIPTION
    $ npm install david
    npm WARN install Refusing to install david as a dependency of itself

Silly david. You cannot depend on yourself.
