### PR TITLE
set npm to be silent when running command

### DIFF
--- a/david.js
+++ b/david.js
@@ -53,7 +53,7 @@ function getDependency(pkgName, callback) {
 				return;
 			}
 			
-			npm.commands.view([pkgName, 'versions'], function(err, data) {
+			npm.commands.view([pkgName, 'versions'], true, function(err, data) {
 				
 				if(err) {
 					callback(err);

--- a/test/david.js
+++ b/test/david.js
@@ -18,7 +18,7 @@ function mockNpm(versions, depName) {
 			callback();
 		},
 		commands: {
-			view: function(args, callback) {
+			view: function(args, silent, callback) {
 				process.nextTick(function() {
 					if(args[0] == depName) {
 						callback(null, npmData);


### PR DESCRIPTION
I'm building a cli tool for david and by default npm outputs all of the versions when running npm.command.  I've just added the option for it to be silent.
