### PR TITLE
prints out a one line command to update dependencies

### DIFF
--- a/bin/david.js
+++ b/bin/david.js
@@ -28,6 +28,12 @@ var printDeps = function(deps, type) {
   } else {
     type = '';
   }
+  var oneline = ['npm install'];
+  if (type == 'Dev ') {
+    oneline.push('--save-dev');
+  } else {
+    oneline.push('--save');
+  }
 
   console.log('');
   console.log('%sOutdated %sDependencies%s', yellow, type, reset);
@@ -35,6 +41,7 @@ var printDeps = function(deps, type) {
 
   for (var name in deps) {
     var dep = deps[name];
+    oneline.push(name+'@'+dep.stable);
     console.log('%s%s%s %s(package:%s %s, %slatest: %s%s%s)%s', 
                 green,
                 name,
@@ -51,6 +58,8 @@ var printDeps = function(deps, type) {
                 reset
                );
   }
+  console.log('');
+  console.log('%s%s%s', gray, oneline.join(' '), reset);
   console.log('');
 }
 


### PR DESCRIPTION
added a command that you can copy and paste to update deps

```
Outdated Dependencies

optimist (package: 0.3.4, latest: 0.3.5)
js-yaml (package: 1.0.2, latest: 2.0.3)
marked (package: 0.2.5, latest: 0.2.8)

npm install --save optimist@0.3.5 js-yaml@2.0.3 marked@0.2.8


Outdated Dev Dependencies

mocha (package: 1.6.0, latest: 1.8.2)
grunt (package: 0.3.17, latest: 0.4.1)
grunt-simple-mocha (package: 0.2.0, latest: 0.3.2)

npm install --save-dev mocha@1.8.2 grunt@0.4.1 grunt-simple-mocha@0.3.2
```
