### PR TITLE
fixed issues with latest/stable version detection

### DIFF
--- a/lib/david.js
+++ b/lib/david.js
@@ -20,12 +20,20 @@ function getLatestVerInfo (name, cb) {
   npm.load({}, function (er) {
     if (er) return cb(er)
     
-    npm.commands.view([name, "versions"], true, function (er, data) {
+    npm.commands.view([name, "versions", "time"], true, function (er, data) {
       if (er) return cb(er)
       
-      var latest = Object.keys(data)[0]
-        , versions = data[latest].versions
-        , stable = getLatestStable(versions)
+      var stable = Object.keys(data)[0]
+        , versions = data[stable].versions.sort(function (a, b) {
+          a = data[stable].time[a]
+          b = data[stable].time[b]
+          return (a < b ? -1 : (a > b ? 1 : 0))
+        })
+        , latest = versions[versions.length-1]
+
+      if (!isStable(stable)) {
+        stable = getLatestStable(versions)
+      }
       
       cb(null, {name: name, latest: latest, stable: stable})
     })


### PR DESCRIPTION
This PR fixes two issues:

1)
'latest' and 'stable' versions weren't detected correctly. For example, if you looked at karma you got stable 0.11.0 and latest 0.10.2, when in reality it is exactly the opposite (stable 0.10.2 and latest 0.11.0). The reason for this is that you assumed that the 'latest' version you get from npm is the 'newest', while the truth is that the 'latest' version you get from npm is simply the version tagged 'latest'. I think that karma is one of the few node modules using this versioning system correctly. 0.10.2 is tagged as 'latest' and the newest (0.11.0) is tagged as 'canary'.

The revised implementation assumes that 'latest' version returned from npm is the 'stable' one, while the 'unstable' is the last version in the version array. Only if the 'stable' version doesn't look like a stable version number, I use the old logic of scanning the version array backwards until I find a version that look like a stable version number.

I also don't like the fact that in david's code 'latest' is used as synonym to 'unstable', I find it confusing especially since in my opinion npm regards 'latest' actually as the 'stable' version.

2)
The code assumes that the version array is sorted from oldest to newest, while actually the array is sorted using semver.compare(), which for example will put 0.0.1-alpha10 _before_ 0.0.1-alpha9 (see for example 'npm view zombie versions'), so in order to fix this I also get the 'time' attribute from 'npm view' and then sort the version array by time
