### PR TITLE
Support --registry to supply an alternate registry

### DIFF
--- a/test/cli.js
+++ b/test/cli.js
@@ -22,7 +22,7 @@ module.exports = {
 
       cp("test/fixtures/test-update/package.json", "test/tmp/test-update/package.json", function () {
 
-        var proc = childProcess.exec("node ../../../bin/david update", { cwd: "test/tmp/test-update" }, function (er) {
+        var proc = childProcess.exec("node ../../../bin/david update --registry http://registry.nodejitsu.com/", { cwd: "test/tmp/test-update" }, function (er) {
           test.ifError(er)
 
           // Should have installed dependencies
@@ -69,7 +69,7 @@ module.exports = {
       
       cp("test/fixtures/test-update/package.json", "test/tmp/test-filtered-update/package.json", function () {
         
-        var proc = childProcess.exec("node ../../../bin/david update async grunt", {cwd: "test/tmp/test-filtered-update"}, function (er) {
+        var proc = childProcess.exec("node ../../../bin/david update async grunt --registry http://registry.npmjs.eu/", {cwd: "test/tmp/test-filtered-update"}, function (er) {
           test.ifError(er)
           
           // Should have installed dependencies


### PR DESCRIPTION
Some of us have private registries, this would allow us to use David unmodified :)

I added --registry (two different public registries) to a couple of tests to ensure that it was working as expected.

Let me know if you need me to do anything else.
