### PR TITLE
test: change devDep from grunt to request in the test

### DIFF
--- a/test/fixtures/test-update/package.json
+++ b/test/fixtures/test-update/package.json
@@ -13,7 +13,7 @@
     "rimraf": "~2.1.4"
   },
   "devDependencies": {
-    "grunt": "~0.3.0",
+    "request": "~0.1.9",
     "mocha": "0.14.x"
   },
   "optionalDependencies": {


### PR DESCRIPTION
This may seem like a silly request, but it does have merit :)

The version of grunt that you are using to test with contains a module that is GPL licensed. Some of us use only permissive licensed code (MIT, BSD, etc) and we can't run these tests since the module in question isn't allowed to be downloaded on our systems.

The module in question is [`gzip-js`](https://www.npmjs.org/package/gzip-js) required by [`grunt@0.3.x`](http://registry.npmjs.org/grunt/0.3.17). I spent a lot of time getting that module replaced due to license issues ;)

I've just replaced `grunt@~0.3.0` with `request@~0.1.9` to get the same results but the tests I can run..

Thanks in advance :)
