### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Coverage Status](http://img.shields.io/coveralls/alanshaw/david.svg?style=flat)](https://coveralls.io/r/alanshaw/david?branch=master)
 [![Dependency Status](https://david-dm.org/alanshaw/david.svg?style=flat)](https://david-dm.org/alanshaw/david)
 [![devDependency Status](https://david-dm.org/alanshaw/david/dev-status.svg?style=flat)](https://david-dm.org/alanshaw/david#info=devDependencies)
+[![Inline docs](http://inch-ci.org/github/alanshaw/david.svg?branch=master)](http://inch-ci.org/github/alanshaw/david)
 [![Donate to help support David development](http://img.shields.io/gratipay/_alanshaw.svg?style=flat)](https://www.gittip.com/_alanshaw/)
 ___
 


### PR DESCRIPTION
Hi Alan,

I want to propose to add this badge to the README to show off inline-documentation: [![Inline docs](http://inch-ci.org/github/alanshaw/david.svg)](http://inch-ci.org/github/alanshaw/david)

The badge links to [Inch CI](http://inch-ci.org) and shows an evaluation by [InchJS](http://trivelop.de/inchjs), a project that tries to raise the visibility of inline-docs in Open Source to encourage aspiring programmers to document their code. So far over 500 **Ruby** projects are sporting these badges to raise awareness for the importance of inline-docs and to show potential contributors that they can expect a certain level of code documentation when they dive into your code.

I would really like to do the same for the **JavaScript** community and roll out support for JS over the coming weeks. Although this is "only" a passion project, I really would like to hear your thoughts, critique and suggestions. Your status page is http://inch-ci.org/github/alanshaw/david/

What do you think?

P.S. Happy second birthday to David :wink:  Great project, I especially like that one can use it offline or via the webservice.

[edit] added link to InchJS