### PR TITLE
Fix typo in warning message for non-string dependencies

### DIFF
--- a/bin/david.js
+++ b/bin/david.js
@@ -42,7 +42,7 @@ function printWarnings (deps, type) {
   var warnings = {
     E404: {title: 'Unregistered', list: []},
     ESCM: {title: 'SCM', list: []},
-    EDEPTYPE: {title: 'Non-strng dependency', list: []}
+    EDEPTYPE: {title: 'Non-string dependency', list: []}
   }
 
   for (var name in deps) {


### PR DESCRIPTION
Just a small typo I noticed while looking at the code.