### PR TITLE
tools: update standard

### DIFF
--- a/bin/david.js
+++ b/bin/david.js
@@ -10,7 +10,7 @@ var argv = require('minimist')(process.argv.slice(2))
 var xtend = require('xtend')
 
 if (argv.usage || argv.help || argv.h) {
-  console.log(fs.readFileSync(__dirname + '/usage.txt', 'utf8'))
+  console.log(fs.readFileSync(path.join(__dirname, 'usage.txt'), 'utf8'))
   process.exit()
 }
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "jshint": "^2.5.1",
     "rewire": "^2.1.0",
     "rimraf": "^2.3.2",
-    "standard": "^5.0.2",
+    "standard": "^6.0.4",
     "tape": "^4.0.0"
   },
   "engines": {


### PR DESCRIPTION
Current version of standard is out of date.

New rule exists about no concatenating paths, updated to use path.

Replaces: #101 which has lint