### PR TITLE
Fixes #105 - now gives a message if all global deps are up-to-date

### DIFF
--- a/bin/david.js
+++ b/bin/david.js
@@ -252,11 +252,15 @@ if (argv.global || argv.g) {
               console.error('Failed to update global dependencies', err)
               exit(1)
             }
-
             printWarnings(deps, 'global')
           })
         } else {
           printDeps(deps, 'global')
+          if (getNonWarnDepNames(deps).length) {
+            exit(1)
+          }
+          // Log feedback if all global dependencies are up to date
+          console.log(clc.green('All global dependencies up to date'))
         }
       })
     })


### PR DESCRIPTION
This adds the same kind of comment to David, when it is being run with '-g' (or --global) switch.
So, if all global packages are up-to-date, David outputs to console: 
**All global dependencies up to date**