### PR TITLE
Fixes a bug where cursor is invisible in CLI, after david has exited …

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "LICENCE"
   ],
   "dependencies": {
+    "ansi": "^0.3.1",
     "async": "^2.0.1",
     "cli-color-tty": "^2.0.0",
     "cli-table": "^0.3.1",


### PR DESCRIPTION
At least versions 7.0.2 to 9.0.0 had a glitch or incompatibility with npm's progress bar, which anyway resulted in cursor being invisible when david exits with "something to report" - ie. non- all dependencies up to date.

This PR contains a fix. It forces a ANSI show cursor command every time david comes out with a exit() clause, in a place where npm has already been called. 

Bad points: adds a new dependency, the package 'ansi'
And further developers should remember also to call cleanUpTTY() before their exit() 's. 