### PR TITLE
Fixes issue #111: prompt missing after a recent npm update

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "LICENCE"
   ],
   "dependencies": {
+    "ansi": "^0.3.1",
     "async": "^2.0.1",
     "cli-color-tty": "^2.0.0",
     "cli-table": "^0.3.1",


### PR DESCRIPTION
New code that always explicitly calls a 'show cursor' using ANSI library.
Thus also 'ansi' added as dependency.
Changes only to cli side, not the lib/david