### PR TITLE
Ignore dependencies via globs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,8 @@ node_js:
   - 5
   - 6
   - 7
+  - 8
+  - 9
+  - 10
 after_script:
   - npm run coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ cache:
 git:
   depth: 5
 node_js:
-  - 8
-  - 9
   - 10
+  - 12
+  - "latest"
 after_script:
   - npm run coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ git:
 node_js:
   - 10
   - 12
-  - "latest"
+  - "stable"
 after_script:
   - npm run coveralls

--- a/README.md
+++ b/README.md
@@ -155,13 +155,13 @@ Use `-p, --package` to specify the path to your package.json.
 
 ### Ignore dependencies
 
-To tell david to ignore dependencies, add a `david.ignore` property to your `package.json` which lists the dependencies david should ignore. If using david programmatically you can also pass this as an option. e.g.
+To tell david to ignore dependencies, add a `david.ignore` property to your `package.json` which lists the dependencies david should ignore. If using david programmatically you can also pass this as an option. Globs are also supported. e.g.
 
 **package.json**
 ```json
 {
   "david": {
-    "ignore": ["async", "underscore"]
+    "ignore": ["async", "underscore", "@types/*"]
   }
 }
 ```

--- a/bin/usage.txt
+++ b/bin/usage.txt
@@ -14,7 +14,7 @@ Options:
   -v, --version    Print version number and exit.
   -r, --registry   The npm registry URL.
                    [default: "https://registry.npmjs.org/"]
-  -i, --ignore     List of dependencies to ignore.
+  -i, --ignore     List of dependency names or globs to ignore.
   --error404       If dependency not found, halt with an error code.
   --errorSCM       If dependency version is a source control URL, halt with an
                    error code.

--- a/lib/david.js
+++ b/lib/david.js
@@ -6,6 +6,7 @@
  * Licensed under the MIT license.
  */
 
+var multimatch = require('multimatch')
 var parallel = require('async/parallel')
 var semver = require('semver')
 var Version = require('./version')
@@ -84,7 +85,7 @@ function depType (opts) {
  * @param {Boolean} [opts.error.E404] Error on 404s
  * @param {Boolean} [opts.versions] For each dependency, return the available versions
  * @param {Boolean} [opts.rangeVersions] For each dependency, return the available versions for the range specified in the package.json
- * @param {Array} [opts.ignore] List of dependency names to ignore
+ * @param {Array} [opts.ignore] List of dependency names or globs to ignore
  * @param {Function} cb Function that receives the results
  */
 function getDependencies (manifest, opts, cb) {
@@ -116,7 +117,7 @@ function getDependencies (manifest, opts, cb) {
 
   var tasks = depNames.map(function (depName) {
     return function (cb) {
-      if (opts.ignore.indexOf(depName) > -1) {
+      if (multimatch(depName, opts.ignore).length > 0) {
         return cb()
       }
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "cli-table": "^0.3.1",
     "exit": "^0.1.2",
     "minimist": "^1.1.0",
+    "multimatch": "^2.1.0",
     "npm": "^4.0.3",
     "semver": "^5.3.0",
     "xtend": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -36,12 +36,12 @@
     "xtend": "^4.0.0"
   },
   "devDependencies": {
-    "coveralls": "^2.11.12",
+    "coveralls": "^3.0.1",
     "istanbul": "^0.4.0",
     "jshint": "^2.5.1",
-    "rewire": "^2.1.0",
+    "rewire": "^4.0.1",
     "rimraf": "^2.5.4",
-    "standard": "^10.0.2",
+    "standard": "^11.0.1",
     "tape": "^4.0.0"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "jshint": "^2.10.2",
     "rewire": "^4.0.1",
     "rimraf": "^2.6.3",
-    "standard": "^13.1.1",
+    "standard": "^14.3.1",
     "tape": "^4.11.0"
   },
   "engines": {

--- a/test/david.js
+++ b/test/david.js
@@ -47,6 +47,45 @@ test('Test getDependencies returns an empty object when passed a manifest with n
   })
 })
 
+test('Test getDependencies ignores specified packages', function (t) {
+  t.plan(4)
+
+  var manifest = {
+    dependencies: {
+      testDepName: '~0.0.2',
+      testDepName2: '~0.3.2'
+    }
+  }
+
+  david.getDependencies(manifest, {ignore: ['testDepName']}, function (err, deps) {
+    t.equal(err, undefined)
+    t.ok(deps)
+    t.ok(deps.testDepName2)
+    t.strictEqual(Object.keys(deps).length, 1)
+    t.end()
+  })
+})
+
+test('Test getDependencies ignores specified package glob', function (t) {
+  t.plan(4)
+
+  var manifest = {
+    dependencies: {
+      testDepName: '~0.0.2',
+      testDepName2: '~0.3.2',
+      testOtherName: '~1.0.2'
+    }
+  }
+
+  david.getDependencies(manifest, {ignore: ['testDep*']}, function (err, deps) {
+    t.equal(err, undefined)
+    t.ok(deps)
+    t.ok(deps.testOtherName)
+    t.strictEqual(Object.keys(deps).length, 1)
+    t.end()
+  })
+})
+
 test('Test getUpdatedDependencies returns an empty object when passed a manifest with no dependencies', function (t) {
   t.plan(3)
 

--- a/test/david.js
+++ b/test/david.js
@@ -57,7 +57,7 @@ test('Test getDependencies ignores specified packages', function (t) {
     }
   }
 
-  david.getDependencies(manifest, {ignore: ['testDepName']}, function (err, deps) {
+  david.getDependencies(manifest, { ignore: ['testDepName'] }, function (err, deps) {
     t.equal(err, undefined)
     t.ok(deps)
     t.ok(deps.testDepName2)
@@ -77,7 +77,7 @@ test('Test getDependencies ignores specified package glob', function (t) {
     }
   }
 
-  david.getDependencies(manifest, {ignore: ['testDep*']}, function (err, deps) {
+  david.getDependencies(manifest, { ignore: ['testDep*'] }, function (err, deps) {
     t.equal(err, undefined)
     t.ok(deps)
     t.ok(deps.testOtherName)


### PR DESCRIPTION
Fixes #135.

This should be backwards compatible, so it could be released with a minor version bump.