### PR TITLE
Update deps and README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,131 @@
+# Changelog
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## 11.0.0 - 2017-03-02
+
+- Update dependencies
+
+## 10.0.0 - 2017-01-20
+
+- Update to npm@4
+
+## 9.0.0 - 2016-08-26
+
+- CLI add global dependencies up to date message
+
+## 8.0.0 - 2016-06-30
+
+- Update dependencies
+
+## 7.0.0 - 2015-11-09
+
+- Update to npm@3
+
+## 6.4.0 - 2015-10-19
+
+- CLI Add `-i, --ignore` option to ignore dependencies
+
+## 6.3.0 - 2015-10-19
+
+- Ignore dependencies from `package.json` config
+
+## 6.2.0 - 2015-08-08
+
+- CLI Add `-p, --package` to specify package.json path
+
+## 6.0.0 - 2014-12-19
+
+- Warn about unregistered or git dependencies by default
+
+## 5.0.0 - 2014-09-22
+
+- Update to semver@4.0.0
+
+## 4.1.0 - 2014-09-22
+
+- Add versions option to return all dependency versions
+
+## 4.0.0 - 2014-09-21
+
+- Update to npm@2.0.2, add rangeVersions option
+
+## 3.3.0 - 2014-06-02
+
+- CLI Add `--warn404` option to print errors but not abort
+
+## 3.1.0 - 2014-03-11
+
+- CLI Add `-r, --registry` option to use alternate npm registry
+
+## 3.0.0 - 2014-03-06
+
+- Errors occurring whilst retrieving dependency status doesn't halt processing of other dependencies.
+- An error object will be returned as first arg to callback, but status info for remaining dependencies will still be available (as second arg).
+- CLI now uses loose semver version parsing.
+- Update npm dependency so `david update` uses "^" as per https://github.com/npm/npm/issues/4587
+
+## 2.4.0 - 2013-10-27
+
+- Removes `semverext.js`. The `gtr` function is now available in `semver`
+
+## 2.3.0 - 2013-10-08
+
+- Support update specific modules from CLI via `david update [module]`
+
+## 2.2.0 - 2013-10-01
+
+- Support for `optionalDependencies` and `peerDependencies`
+
+## 2.1.0 - 2013-09-16
+
+- Fixed issues with latest/stable version detection
+
+## 2.0.0 - 2013-08-25
+
+- Simplification refactor to remove caching and useless events.
+- Code style changes, performance improvements.
+
+## 1.9.0 - 2013-08-04
+
+- CLI added `--unstable` flag to view/update to latest _unstable_ dependency versions
+
+## 1.8.0 - 2013-07-30
+
+- CLI added `david update` to update dependencies to latest _stable_ versions and save to your project `package.json`
+
+## 1.7.0 - 2013-06-27
+
+- Updated to use semver 2 module
+- Simplified code that determines if a version is greater than a range
+
+## 1.6.0 - 2013-03-28
+
+- Use `setImmediate` instead of `process.nextTick`.
+- David now requires Node.js 0.10.x
+
+## 1.5.0 - 2013-03-27
+
+- CLI added `--global` flag to find outdated global dependencies
+
+## 1.4.0 - 2013-03-15
+
+- Allow set the maximum number of dependencies that can be stored in the cache
+
+## 1.3.0 - 2013-03-14
+
+- Added CLI support
+
+## 1.2.0 - 2013-03-05
+
+- David can now get dependency information for `devDependencies`
+
+## 1.1.0 - 2013-02-07
+
+- Adds `onlyStable` param to `getUpdatedDependencies` to filter by dependencies that are updated and stable
+
+## 1.0.0 - 2013-02-06
+
+- Return latest stable version as well as latest version (including patch and build versions).
+- API return values changed.
+- Events changed.

--- a/README.md
+++ b/README.md
@@ -201,4 +201,6 @@ Release History
 
 ---
 
-[![js-standard-style](https://cdn.rawgit.com/feross/standard/master/badge.svg)](https://github.com/feross/standard)
+<p align="center">
+<a href="https://github.com/feross/standard"><img src="https://cdn.rawgit.com/feross/standard/master/badge.svg" alt="js-standard-style"></a>
+</p>

--- a/README.md
+++ b/README.md
@@ -165,40 +165,6 @@ To tell david to ignore dependencies, add a `david.ignore` property to your `pac
 }
 ```
 
-
-Release History
----------------
-
-* 2017-01-20   v10.0.0   Update to npm@4
-* 2016-08-26   v9.0.0   CLI add global dependencies up to date message
-* 2016-06-30   v8.0.0   Update dependencies
-* 2015-11-09   v7.0.0   Update to npm@3
-* 2015-10-19   v6.4.0   CLI Add `-i, --ignore` option to ignore dependencies
-* 2015-10-19   v6.3.0   Ignore dependencies from `package.json` config
-* 2015-08-08   v6.2.0   CLI Add `-p, --package` to specify package.json path
-* 2014-12-19   v6.0.0   Warn about unregistered or git dependencies by default
-* 2014-09-22   v5.0.0   Update to semver@4.0.0
-* 2014-09-22   v4.1.0   Add versions option to return all dependency versions
-* 2014-09-21   v4.0.0   Update to npm@2.0.2, add rangeVersions option
-* 2014-06-02   v3.3.0   CLI Add `--warn404` option to print errors but not abort
-* 2014-03-11   v3.1.0   CLI Add `-r, --registry` option to use alternate npm registry
-* 2014-03-06   v3.0.0   Errors occurring whilst retrieving dependency status doesn't halt processing of other dependencies. An error object will be returned as first arg to callback, but status info for remaining dependencies will still be available (as second arg). CLI now uses loose semver version parsing. Also update npm dependency so `david update` uses "^" as per https://github.com/npm/npm/issues/4587
-* 2013-10-27   v2.4.0   Removes `semverext.js`. The `gtr` function is now available in `semver`
-* 2013-10-08   v2.3.0   Support update specific modules from CLI via `david update [module]`
-* 2013-10-01   v2.2.0   Support for `optionalDependencies` and `peerDependencies`
-* 2013-09-16   v2.1.0   Fixed issues with latest/stable version detection
-* 2013-08-25   v2.0.0   Simplification refactor to remove caching and useless events. Code style changes, performance improvements.
-* 2013-08-04   v1.9.0   CLI added `--unstable` flag to view/update to latest _unstable_ dependency versions
-* 2013-07-30   v1.8.0   CLI added `david update` to update dependencies to latest _stable_ versions and save to your project `package.json`
-* 2013-06-27   v1.7.0   Updated to use semver 2 module. Simplified code that determines if a version is greater than a range
-* 2013-03-28   v1.6.0   Use `setImmediate` instead of `process.nextTick`. David now requires Node.js 0.10.x
-* 2013-03-27   v1.5.0   CLI added `--global` flag to find outdated global dependencies
-* 2013-03-15   v1.4.0   Allow set the maximum number of dependencies that can be stored in the cache
-* 2013-03-14   v1.3.0   Added CLI support
-* 2013-03-05   v1.2.0   David can now get dependency information for `devDependencies`
-* 2013-02-07   v1.1.0   Adds `onlyStable` param to `getUpdatedDependencies` to filter by dependencies that are updated and stable
-* 2013-02-06   v1.0.0   Return latest stable version as well as latest version (including patch and build versions). API return values changed. Events changed.
-
 ---
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
 <p align="center"><a href="https://david-dm.org"><img src="https://raw.github.com/alanshaw/david-www/master/david-logo.png" alt="David" height="50" /></a></p>
 <p align="center">
 <a href="https://www.npmjs.com/package/david"><img src="https://img.shields.io/npm/v/david.svg" alt="npm version"></a>
+<a href="http://inch-ci.org/github/alanshaw/david"><img src="http://inch-ci.org/github/alanshaw/david.svg?branch=master" alt="Inline docs"></a>
 <a href="https://travis-ci.org/alanshaw/david"><img src="https://travis-ci.org/alanshaw/david.svg" alt="Build Status"></a>
 <a href="https://coveralls.io/r/alanshaw/david?branch=master"><img src="http://img.shields.io/coveralls/alanshaw/david.svg?style=flat" alt="Coverage Status"></a>
 <a href="https://david-dm.org/alanshaw/david"><img src="https://david-dm.org/alanshaw/david.svg" alt="Dependency Status"></a>
 <a href="https://david-dm.org/alanshaw/david/?type=dev"><img src="https://david-dm.org/alanshaw/david/dev-status.svg" alt="devDependency Status"></a>
-<a href="http://inch-ci.org/github/alanshaw/david"><img src="http://inch-ci.org/github/alanshaw/david.svg?branch=master" alt="Inline docs"></a>
-<a href="https://www.gittip.com/_alanshaw/"><img src="http://img.shields.io/gratipay/_alanshaw.svg?style=flat" alt="Donate to help support David development"></a>
 </p>
 
 Node.js module that tells you when your package npm dependencies are out of date.

--- a/bin/david.js
+++ b/bin/david.js
@@ -41,9 +41,9 @@ function printWarnings (deps, type) {
   if (!Object.keys(deps).length) return
 
   var warnings = {
-    E404: {title: 'Unregistered', list: []},
-    ESCM: {title: 'SCM', list: []},
-    EDEPTYPE: {title: 'Non-string dependency', list: []}
+    E404: { title: 'Unregistered', list: [] },
+    ESCM: { title: 'SCM', list: [] },
+    EDEPTYPE: { title: 'Non-string dependency', list: [] }
   }
 
   for (var name in deps) {
@@ -59,7 +59,7 @@ function printWarnings (deps, type) {
 
     if (!warnList.length) return
 
-    var table = new Table({head: ['Name', 'Message'], style: {head: ['reset']}})
+    var table = new Table({ head: ['Name', 'Message'], style: { head: ['reset'] } })
 
     console.log(clc.underline(warnings[warnType].title + ' ' + (type ? type + 'D' : 'd') + 'ependencies') + '\n')
     warnList.forEach(function (row) { table.push(row) })
@@ -91,7 +91,7 @@ function printDeps (deps, type) {
       console.log(clc.underline('dependencies'))
     }
 
-    var table = new Table({head: ['Name', 'Package', 'Latest'], style: {head: ['reset']}})
+    var table = new Table({ head: ['Name', 'Package', 'Latest'], style: { head: ['reset'] } })
 
     nonWarnDepNames.forEach(function (name) {
       var dep = deps[name]
@@ -142,16 +142,16 @@ function getUpdatedDeps (pkg, cb) {
   }
 
   if (argv.registry) {
-    opts.npm = {registry: argv.registry}
+    opts.npm = { registry: argv.registry }
   }
 
   david.getUpdatedDependencies(pkg, opts, function (err, deps) {
     if (err) return cb(err)
 
-    david.getUpdatedDependencies(pkg, xtend(opts, {dev: true}), function (err, devDeps) {
+    david.getUpdatedDependencies(pkg, xtend(opts, { dev: true }), function (err, devDeps) {
       if (err) return cb(err)
 
-      david.getUpdatedDependencies(pkg, xtend(opts, {optional: true}), function (err, optionalDeps) {
+      david.getUpdatedDependencies(pkg, xtend(opts, { optional: true }), function (err, optionalDeps) {
         cb(err, filterDeps(deps), filterDeps(devDeps), filterDeps(optionalDeps))
       })
     })
@@ -184,7 +184,7 @@ function installDeps (deps, opts, cb) {
     return !deps[depName].warn
   })
 
-  var npmOpts = {global: opts.global}
+  var npmOpts = { global: opts.global }
 
   // Avoid warning message from npm for invalid registry url
   if (opts.registry) {
@@ -212,7 +212,7 @@ function installDeps (deps, opts, cb) {
 }
 
 if (argv.global || argv.g) {
-  var opts = {global: true}
+  var opts = { global: true }
 
   // Avoid warning message from npm for invalid registry url
   if (argv.registry) {
@@ -296,7 +296,7 @@ if (argv.global || argv.g) {
     }
 
     if (argv.update) {
-      var opts = {save: true, registry: argv.registry, path: pkgDir}
+      var opts = { save: true, registry: argv.registry, path: pkgDir }
 
       installDeps(deps, opts, function (err) {
         if (err) {
@@ -304,13 +304,13 @@ if (argv.global || argv.g) {
           exit(1)
         }
 
-        installDeps(devDeps, xtend(opts, {dev: true}), function (err) {
+        installDeps(devDeps, xtend(opts, { dev: true }), function (err) {
           if (err) {
             console.error('Failed to update/save devDependencies', err)
             exit(1)
           }
 
-          installDeps(optionalDeps, xtend(opts, {optional: true}), function (err) {
+          installDeps(optionalDeps, xtend(opts, { optional: true }), function (err) {
             if (err) {
               console.error('Failed to update/save optionalDependencies', err)
               exit(1)

--- a/lib/david.js
+++ b/lib/david.js
@@ -127,7 +127,7 @@ function getDependencies (manifest, opts, cb) {
         err.code = 'EDEPTYPE'
 
         if (!opts.error.EDEPTYPE) {
-          pkgs[depName] = {required: deps[depName], warn: err}
+          pkgs[depName] = { required: deps[depName], warn: err }
         } else {
           error = err
         }
@@ -140,7 +140,7 @@ function getDependencies (manifest, opts, cb) {
         err.code = 'ESCM'
 
         if (!opts.error.ESCM) {
-          pkgs[depName] = {required: deps[depName], warn: err}
+          pkgs[depName] = { required: deps[depName], warn: err }
         } else {
           error = err
         }
@@ -157,7 +157,7 @@ function getDependencies (manifest, opts, cb) {
               err.code = 'E404'
             }
 
-            pkgs[depName] = {required: deps[depName], warn: err}
+            pkgs[depName] = { required: deps[depName], warn: err }
           } else {
             error = err
           }

--- a/package.json
+++ b/package.json
@@ -25,23 +25,23 @@
     "LICENCE"
   ],
   "dependencies": {
-    "async": "^2.0.1",
+    "async": "^3.1.0",
     "cli-color-tty": "^2.0.0",
     "cli-table": "^0.3.1",
     "exit": "^0.1.2",
     "minimist": "^1.1.0",
-    "npm": "^4.0.3",
-    "semver": "^5.3.0",
+    "npm": "^6.10.2",
+    "semver": "^6.3.0",
     "xtend": "^4.0.0"
   },
   "devDependencies": {
-    "coveralls": "^2.11.12",
-    "istanbul": "^0.4.0",
-    "jshint": "^2.5.1",
-    "rewire": "^2.1.0",
-    "rimraf": "^2.5.4",
-    "standard": "^10.0.2",
-    "tape": "^4.0.0"
+    "coveralls": "^3.0.5",
+    "istanbul": "^0.4.5",
+    "jshint": "^2.10.2",
+    "rewire": "^4.0.1",
+    "rimraf": "^2.6.3",
+    "standard": "^13.1.0",
+    "tape": "^4.11.0"
   },
   "engines": {
     "node": ">=0.10.1"

--- a/test/cli.js
+++ b/test/cli.js
@@ -166,9 +166,9 @@ test('Test print-only output with unregistered dependency in each type', functio
       t.ok(new RegExp(depName, 'm').test(stdout.toString()), depName + ' expected to be outdated')
     })
 
-    t.ok(/Error: Registry returned 404 for GET on https:\/\/registry.npmjs.org\/unregistered--/m.test(stdout.toString()))
-    t.ok(/Error: Registry returned 404 for GET on https:\/\/registry.npmjs.org\/unregistereddev--/m.test(stdout.toString()))
-    t.ok(/Error: Registry returned 404 for GET on https:\/\/registry.npmjs.org\/unregisteredopt--/m.test(stdout.toString()))
+    t.notOk(/Error: Registry returned 404 for GET on https:\/\/registry.npmjs.org\/unregistered--/m.test(stdout.toString()))
+    t.notOk(/Error: Registry returned 404 for GET on https:\/\/registry.npmjs.org\/unregistereddev--/m.test(stdout.toString()))
+    t.notOk(/Error: Registry returned 404 for GET on https:\/\/registry.npmjs.org\/unregisteredopt--/m.test(stdout.toString()))
 
     t.end()
   })
@@ -180,9 +180,9 @@ test('Test default exit response to unregistered dependency', function (t) {
   runDavid([], 'test-unregistered', function (err, stdout) {
     // There are dependencies to be updated, so we expect non zero exit code
     t.ok(err.code, 'Exited with non zero exit code')
-    t.ok(/Error: Registry returned 404 for GET on https:\/\/registry.npmjs.org\/unregistered--/m.test(stdout.toString()))
-    t.ok(/Error: Registry returned 404 for GET on https:\/\/registry.npmjs.org\/unregistereddev--/m.test(stdout.toString()))
-    t.ok(/Error: Registry returned 404 for GET on https:\/\/registry.npmjs.org\/unregisteredopt--/m.test(stdout.toString()))
+    t.notOk(/Error: Registry returned 404 for GET on https:\/\/registry.npmjs.org\/unregistered--/m.test(stdout.toString()))
+    t.notOk(/Error: Registry returned 404 for GET on https:\/\/registry.npmjs.org\/unregistereddev--/m.test(stdout.toString()))
+    t.notOk(/Error: Registry returned 404 for GET on https:\/\/registry.npmjs.org\/unregisteredopt--/m.test(stdout.toString()))
     t.end()
   })
 })
@@ -223,9 +223,9 @@ test('Test update with unregistered dependency in each type', function (t) {
       t.notEqual(pkg.optionalDependencies[depName], updatedPkg.optionalDependencies[depName], depName + ' version expected to have changed')
     })
 
-    t.ok(/Error: Registry returned 404 for GET on https:\/\/registry.npmjs.org\/unregistered--/m.test(stdout.toString()))
-    t.ok(/Error: Registry returned 404 for GET on https:\/\/registry.npmjs.org\/unregistereddev--/m.test(stdout.toString()))
-    t.ok(/Error: Registry returned 404 for GET on https:\/\/registry.npmjs.org\/unregisteredopt--/m.test(stdout.toString()))
+    t.notOk(/Error: Registry returned 404 for GET on https:\/\/registry.npmjs.org\/unregistered--/m.test(stdout.toString()))
+    t.notOk(/Error: Registry returned 404 for GET on https:\/\/registry.npmjs.org\/unregistereddev--/m.test(stdout.toString()))
+    t.notOk(/Error: Registry returned 404 for GET on https:\/\/registry.npmjs.org\/unregisteredopt--/m.test(stdout.toString()))
 
     t.end()
   })

--- a/test/cli.js
+++ b/test/cli.js
@@ -40,7 +40,7 @@ function runDavid (args, fixture, cb) {
 
         cp(fixturePkgPath, tmpPkgPath, function () {
           args = [davidPath].concat(args)
-          var opts = {cwd: path.join(tmpPath, fixture)}
+          var opts = { cwd: path.join(tmpPath, fixture) }
           var proc = childProcess.execFile('node', args, opts, cb)
 
           proc.stdout.pipe(process.stdout)

--- a/test/david.js
+++ b/test/david.js
@@ -557,7 +557,7 @@ test('Test `npm view 0 versions` does not throw!', function (t) {
 
   Npm.__set__('npm', npmMock)
 
-  var manifest = {dependencies: ['0']}
+  var manifest = { dependencies: ['0'] }
 
   t.doesNotThrow(function () {
     david.getDependencies(manifest, function () {})
@@ -577,9 +577,9 @@ test('Test error whilst getting dependency status doesn\'t cause remaining proce
       view: function (args, silent, cb) {
         process.nextTick(function () {
           if (args[0] === 'testDepName') {
-            cb(null, {'0.0.1rc1': {versions: ['0.0.1rc1', '1.0.0'], time: [new Date().toISOString()]}})
+            cb(null, { '0.0.1rc1': { versions: ['0.0.1rc1', '1.0.0'], time: [new Date().toISOString()] } })
           } else {
-            cb(null, {'1.2.3': {versions: ['1.2.3'], time: [new Date().toISOString()]}})
+            cb(null, { '1.2.3': { versions: ['1.2.3'], time: [new Date().toISOString()] } })
           }
         })
       }
@@ -596,7 +596,7 @@ test('Test error whilst getting dependency status doesn\'t cause remaining proce
   }
 
   // Force and error to be returned by david, by specifying dependecy as invalid semver (but valid loose semver)
-  david.getDependencies(manifest, {loose: false}, function (err, deps) {
+  david.getDependencies(manifest, { loose: false }, function (err, deps) {
     t.ok(err) // An error object should have been passed back
     t.ok(deps) // A deps object containing only testDepName2 should have been passed back
     t.ok(!deps.testDepName)
@@ -618,7 +618,7 @@ test('Return dependency versions when versions option is true', function (t) {
     commands: {
       view: function (args, silent, cb) {
         process.nextTick(function () {
-          cb(null, {'1.1.0': {versions: ['0.2.0', '1.0.1', '1.1.0']}})
+          cb(null, { '1.1.0': { versions: ['0.2.0', '1.0.1', '1.1.0'] } })
         })
       }
     }
@@ -632,7 +632,7 @@ test('Return dependency versions when versions option is true', function (t) {
     }
   }
 
-  david.getDependencies(manifest, {loose: true, versions: true}, function (err, deps) {
+  david.getDependencies(manifest, { loose: true, versions: true }, function (err, deps) {
     t.ifError(err)
     t.ok(deps)
     t.ok(deps.testDepName)
@@ -655,7 +655,7 @@ test('Return dependency versions satisfying ranges when rangeVersions option is 
     commands: {
       view: function (args, silent, cb) {
         process.nextTick(function () {
-          cb(null, {'1.1.0': {versions: ['0.2.0', '1.0.1', '1.1.0']}})
+          cb(null, { '1.1.0': { versions: ['0.2.0', '1.0.1', '1.1.0'] } })
         })
       }
     }
@@ -669,7 +669,7 @@ test('Return dependency versions satisfying ranges when rangeVersions option is 
     }
   }
 
-  david.getDependencies(manifest, {loose: true, rangeVersions: true}, function (err, deps) {
+  david.getDependencies(manifest, { loose: true, rangeVersions: true }, function (err, deps) {
     t.ifError(err)
     t.ok(deps)
     t.ok(deps.testDepName)
@@ -715,7 +715,7 @@ test('Test non-string dependency doesn\'t throw', function (t) {
     }
   }
 
-  david.getDependencies(manifest, {error: {EDEPTYPE: true}}, function (err) {
+  david.getDependencies(manifest, { error: { EDEPTYPE: true } }, function (err) {
     t.ok(err, 'Expected error')
     t.equal(err.code, 'EDEPTYPE', 'Expected error code EDEPTYPE')
     t.end()


### PR DESCRIPTION
Close #148

It has been more than 14 months since the last update to this repo. This PR updates deps and devdeps, removes the gittip badge/shield, moves 'Release History' to CHANGELOG.md and fixes linting and failing tests.