### PR TITLE
Use object shorthand for properties

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -47,7 +47,7 @@ function getVersionsInfo (name, opts, cb) {
       }
 
       batch.call(name, function (cb) {
-        cb(null, { current: currentVersion, versions: versions })
+        cb(null, { current: currentVersion, versions })
       })
     })
   })

--- a/lib/version.js
+++ b/lib/version.js
@@ -73,7 +73,7 @@ function getLatest (current, versions, opts) {
     }
   }
 
-  return { latest: latest, stable: stable }
+  return { latest, stable }
 }
 
 exports.getLatest = getLatest

--- a/test/david.js
+++ b/test/david.js
@@ -15,7 +15,7 @@ function mockNpm (versions, depName, latestTag) {
   versions.forEach(function (value, index) { time[value] = new Date(index).toISOString() })
   latestTag = latestTag || versions[versions.length - 1]
   versions.sort(function (a, b) { return semver.compare(a, b) })
-  npmData[latestTag] = { versions: versions, time: time }
+  npmData[latestTag] = { versions, time }
 
   // Mock out NPM
   return {


### PR DESCRIPTION
This rule is on its way into the latest Standard ☺️ 

ref: https://github.com/standard/eslint-config-standard/pull/166